### PR TITLE
Refactoring API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,24 @@
 [package]
-name = "frank_jwt"
-version = "2.6.0"
 authors = ["Alex Maslakov <me@gildedhonour.com>, <gilded.honour@protonmail.com>"]
-license = "Apache-2.0"
-
-homepage = "https://github.com/GildedHonour/frank_jwt"
-repository = "https://github.com/GildedHonour/frank_jwt"
-documentation = "https://github.com/GildedHonour/frank_jwt"
-
 description = "Implementation of JSON JWT"
-keywords = ["jwt", "json", "token", "encryption", "auth0-jwt"]
+documentation = "https://github.com/GildedHonour/frank_jwt"
+homepage = "https://github.com/GildedHonour/frank_jwt"
+keywords = [
+    "jwt",
+    "json",
+    "token",
+    "encryption",
+    "auth0-jwt",
+]
+license = "Apache-2.0"
+name = "frank_jwt"
 readme = "README.md"
+repository = "https://github.com/GildedHonour/frank_jwt"
+version = "2.6.0"
 
 [dependencies]
-rustc-serialize = "0.3.24"
-time = "0.1.37"
-openssl = "~0.9.12"
+base64 = "0.9.0"
+openssl = "^0.9"
+serde = "^1"
+serde_json = "^1"
+time = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Alex Maslakov <me@gildedhonour.com>, <gilded.honour@protonmail.com>"]
+authors = ["Alex Maslakov <me@gildedhonour.com>, <gilded.honour@protonmail.com>", "Rick Richardson <rick.richardson@gmail.com>"]
 description = "Implementation of JSON JWT"
 documentation = "https://github.com/GildedHonour/frank_jwt"
 homepage = "https://github.com/GildedHonour/frank_jwt"

--- a/README.md
+++ b/README.md
@@ -36,36 +36,42 @@ And this in your crate root:
 
 ```rust
 extern crate frank_jwt;
-
-use frank_jwt::{Header, Payload, Algorithm, encode, decode};
+#[macro_use]
+serde_json;
+use frank_jwt::{Algorithm, encode, decode};
 ```
 
 ## Example
 
 ```rust
 //HS256
-let mut payload = Payload::new();
-payload.insert("key1".to_string(), "val1".to_string());
-payload.insert("key2".to_string(), "val2".to_string());
-let header = Header::new(Algorithm::HS256);
+let mut payload = json!({
+    "key1" : "val1",
+    "key2" : "val2"
+});
+let mut header = json!({
+});
 let secret = "secret123";
 
-let jwt = encode(header, secret.to_string(), payload.clone());
+let jwt = encode(&header, secret.to_string(), &payload, Algorithm::HS256);
 
 //RS256
 use std::env;
 
-let mut payload = Payload::new();
-payload.insert("key1".to_string(), "val1".to_string());
-payload.insert("key2".to_string(), "val2".to_string());
-let header = Header::new(Algorithm::RS256);
+let mut payload = json!({
+    "key1" : "val1",
+    "key2" : "val2"
+});
+let mut header = json!({
+});
 
-let mut path = env::current_dir().unwrap();
-path.push("some_folder");
-path.push("my_rsa_2048_key.pem");
-let key_path = path.to_str().unwrap().to_string();
+let mut keypath = env::current_dir().unwrap();
+keypath.push("some_folder");
+keypath.push("my_rsa_2048_key.pem");
 
-let jwt = encode(header, key_path, payload.clone());
+let jwt = encode(&header, &keypath.to_path_buf(), &payload, Algorithm::RS256);
+
+let (header, payload) = decode(&jwt, &keypath.to_path_buf(), Algorithm::RS256);
 ```
 
 ## License

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,21 @@
  *
  */
 
+use std::io::Error as IoError;
+use serde_json::Error as SJError;
+use openssl::error::ErrorStack;
+use base64::DecodeError as B64Error;
+
+macro_rules! impl_error {
+    ($from:ty, $to:path) => {
+        impl From<$from> for Error {
+            fn from(e: $from) -> Self {
+                $to(format!("{:?}", e))
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum Error {
     SignatureExpired,
@@ -26,5 +41,14 @@ pub enum Error {
     JWTInvalid,
     IssuerInvalid,
     ExpirationInvalid,
-    AudienceInvalid
+    AudienceInvalid,
+    FormatInvalid(String),
+    IoError(String),
+    OpenSslError(String),
+    ProtocolError(String),
 }
+
+impl_error!{IoError, Error::IoError}
+impl_error!{SJError, Error::FormatInvalid}
+impl_error!{ErrorStack, Error::OpenSslError}
+impl_error!{B64Error, Error::ProtocolError}

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,7 +34,7 @@ macro_rules! impl_error {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     SignatureExpired,
     SignatureInvalid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,8 +408,9 @@ mod tests {
         let header = json!({});
 
         let jwt1 = encode(header, &get_ec_private_key_path(), &p1, Algorithm::ES512).unwrap();
-        let maybe_res = decode(&jwt1, &get_ec_public_key_path(), Algorithm::ES512);
-        assert!(maybe_res.is_ok());
+        let (header, payload) = decode(&jwt1, &get_ec_public_key_path(), Algorithm::ES512).unwrap();
+        assert_eq!(p1, payload);
+
     }
 
     fn get_ec_private_key_path() -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use openssl::ec::EcKey;
 use serde_json::Value as JsonValue;
 use base64::{encode_config as b64_enc, decode_config as b64_dec};
 
-use error::Error;
+pub use error::Error;
 
 const SEGMENTS_COUNT: usize = 3;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2018 Alex Maslakov, <gildedhonour.com>, <alexmaslakov.me>
+ (c) 2015-2018 Alex Maslakov, <gildedhonour.com>, <alexmaslakov.me>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,14 +23,18 @@ extern crate time;
 extern crate openssl;
 extern crate serde;
 extern crate base64;
-
+   
+#[cfg(test)]
 #[macro_use]
+extern crate serde_json;
+
+#[cfg(not(test))]
 extern crate serde_json;
 
 pub mod error;
 
 use std::fs::File;
-use std::path::Path;
+use std::path::{PathBuf};
 use std::io::Read;
 use std::str;
 use openssl::hash::MessageDigest;
@@ -38,7 +42,6 @@ use openssl::pkey::PKey;
 use openssl::rsa::Rsa;
 use openssl::sign::{Signer, Verifier};
 use openssl::ec::EcKey;
-use serde::{Serialize};
 use serde_json::Value as JsonValue;
 use base64::{encode_config as b64_enc, decode_config as b64_dec};
 
@@ -48,7 +51,7 @@ const SEGMENTS_COUNT: usize = 3;
 
 const STANDARD_HEADER_TYPE: &str = "JWT";
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Algorithm {
     HS256,
     HS384,
@@ -77,19 +80,39 @@ impl ToString for Algorithm {
     }
 }
 
-pub fn encode<P: AsRef<Path>>(mut header: JsonValue, algorithm: &Algorithm, signing_key: &P, payload: &JsonValue) -> Result<String, Error> {
+pub trait ToKey {
+    fn to_key(&self) -> Result<Vec<u8>, Error>;
+}
+
+impl ToKey for PathBuf {
+    fn to_key(&self) -> Result<Vec<u8>, Error> {
+        let mut file = File::open(self)?;
+        let mut buffer:Vec<u8> = Vec::new();
+        file.read_to_end(&mut buffer)?;
+        Ok(buffer)
+    }
+}
+
+impl ToKey for String {
+    fn to_key(&self) -> Result<Vec<u8>, Error> {
+        Ok(self.as_bytes().to_vec())
+    }
+}
+
+pub fn encode<P: ToKey>(mut header: JsonValue, signing_key: &P, payload: &JsonValue, algorithm: Algorithm) -> Result<String, Error> {
     header["alg"] = JsonValue::String(algorithm.to_string());
-    let signing_input = get_signing_input(&payload, &header, algorithm)?;
-    let signature = match *algorithm {
-        Algorithm::HS256 | Algorithm::HS384 | Algorithm::HS512 => sign_hmac(&signing_input, signing_key, *algorithm)?,
-        Algorithm::RS256 | Algorithm::RS384 | Algorithm::RS512 => sign_rsa(&signing_input, signing_key, *algorithm)?,
-        Algorithm::ES256 | Algorithm::ES384 | Algorithm::ES512 => sign_es(&signing_input, signing_key, *algorithm)?,
+    header["typ"] = JsonValue::String(STANDARD_HEADER_TYPE.to_owned());
+    let signing_input = get_signing_input(&payload, &header)?;
+    let signature = match algorithm {
+        Algorithm::HS256 | Algorithm::HS384 | Algorithm::HS512 => sign_hmac(&signing_input, signing_key, algorithm)?,
+        Algorithm::RS256 | Algorithm::RS384 | Algorithm::RS512 => sign_rsa(&signing_input, signing_key, algorithm)?,
+        Algorithm::ES256 | Algorithm::ES384 | Algorithm::ES512 => sign_es(&signing_input, signing_key, algorithm)?,
     };
 
     Ok(format!("{}.{}", signing_input, signature))
 }
 
-pub fn decode<P: AsRef<Path>>(encoded_token: String, signing_key: P, algorithm: Algorithm) -> Result<(JsonValue, JsonValue), Error> {
+pub fn decode<P: ToKey>(encoded_token: &String, signing_key: &P, algorithm: Algorithm) -> Result<(JsonValue, JsonValue), Error> {
     let (header, payload, signature, signing_input) = decode_segments(encoded_token)?;
     if !verify_signature(algorithm, signing_input, &signature, signing_key)? {
         Err(Error::SignatureInvalid)
@@ -98,7 +121,7 @@ pub fn decode<P: AsRef<Path>>(encoded_token: String, signing_key: P, algorithm: 
     }
 }
 
-fn get_signing_input(payload: &JsonValue, header: &JsonValue, algorithm: &Algorithm) -> Result<String, Error> {
+fn get_signing_input(payload: &JsonValue, header: &JsonValue) -> Result<String, Error> {
     
     let header_json_str = serde_json::to_string(header)?;
     let encoded_header = b64_enc(header_json_str.as_bytes(), base64::URL_SAFE);
@@ -107,7 +130,7 @@ fn get_signing_input(payload: &JsonValue, header: &JsonValue, algorithm: &Algori
     Ok(format!("{}.{}", encoded_header, encoded_payload))
 }
 
-fn sign_hmac<P: AsRef<Path>>(data: &str, key_path: P, algorithm: Algorithm) -> Result<String, Error> {
+fn sign_hmac<P: ToKey>(data: &str, key_path: &P, algorithm: Algorithm) -> Result<String, Error> {
     let stp = match algorithm {
         Algorithm::HS256 => MessageDigest::sha256(),
         Algorithm::HS384 => MessageDigest::sha384(),
@@ -115,15 +138,14 @@ fn sign_hmac<P: AsRef<Path>>(data: &str, key_path: P, algorithm: Algorithm) -> R
         _  => panic!("Invalid hmac algorithm")
     };
 
-    let buffer = read_key_file(key_path)?;
-    let key = PKey::hmac(&buffer)?;
+    let key = PKey::hmac(&key_path.to_key()?)?;
     let mut signer = Signer::new(stp, &key)?;
     signer.update(data.as_bytes())?;
     let hmac = signer.sign_to_vec()?;
     Ok(b64_enc(hmac.as_slice(), base64::URL_SAFE))
 }
 
-fn sign_rsa<P: AsRef<Path>>(data: &str, private_key_path: P, algorithm: Algorithm) -> Result<String, Error> {
+fn sign_rsa<P: ToKey>(data: &str, private_key_path: &P, algorithm: Algorithm) -> Result<String, Error> {
     let stp = match algorithm {
         Algorithm::RS256 => MessageDigest::sha256(),
         Algorithm::RS384 => MessageDigest::sha384(),
@@ -131,15 +153,13 @@ fn sign_rsa<P: AsRef<Path>>(data: &str, private_key_path: P, algorithm: Algorith
         _  => panic!("Invalid hmac algorithm")
     };
 
-    let buffer = read_key_file(private_key_path)?;
-    let rsa = Rsa::private_key_from_pem(&buffer)?;
+    let rsa = Rsa::private_key_from_pem(&private_key_path.to_key()?)?;
     let key = PKey::from_rsa(rsa)?;
     sign(data, key, stp)
 }
 
-fn sign_es<P: AsRef<Path>>(data: &str, private_key_path: P, algorithm: Algorithm) -> Result<String, Error> {
-    let raw_key = read_key_file(private_key_path)?;
-    let ec_key = EcKey::private_key_from_pem(&raw_key)?;
+fn sign_es<P: ToKey>(data: &str, private_key_path: &P, algorithm: Algorithm) -> Result<String, Error> {
+    let ec_key = EcKey::private_key_from_pem(&private_key_path.to_key()?)?;
     let key = PKey::from_ec_key(ec_key)?;
     let stp = match algorithm {
         Algorithm::ES256 => MessageDigest::sha256(),
@@ -158,14 +178,7 @@ fn sign(data: &str, private_key:PKey,digest: MessageDigest) -> Result<String, Er
     Ok(b64_enc(signature.as_slice(), base64::URL_SAFE))
 }
 
-fn read_key_file<P: AsRef<Path>>(private_key_path: P) -> Result<Vec<u8>, Error> {
-    let mut file = File::open(private_key_path)?;
-    let mut buffer:Vec<u8> = Vec::new();
-    file.read_to_end(&mut buffer)?;
-    Ok(buffer)
-}
-
-fn decode_segments(encoded_token: String) -> Result<(JsonValue, JsonValue, Vec<u8>, String), Error> {
+fn decode_segments(encoded_token: &String) -> Result<(JsonValue, JsonValue, Vec<u8>, String), Error> {
     let raw_segments: Vec<&str> = encoded_token.split(".").collect();
     if raw_segments.len() != SEGMENTS_COUNT {
         return Err(Error::JWTInvalid);
@@ -190,7 +203,7 @@ fn decode_header_and_payload(header_segment: &str, payload_segment: &str) -> Res
     Ok((header_json, payload_json))
 }
 
-fn sign_hmac2<P: AsRef<Path>>(data: &str, key_path: P, algorithm: Algorithm) -> Result<Vec<u8>, Error> {
+fn sign_hmac2(data: &str, key: &Vec<u8>, algorithm: Algorithm) -> Result<Vec<u8>, Error> {
     let stp = match algorithm {
         Algorithm::HS256 => MessageDigest::sha256(),
         Algorithm::HS384 => MessageDigest::sha384(),
@@ -198,23 +211,21 @@ fn sign_hmac2<P: AsRef<Path>>(data: &str, key_path: P, algorithm: Algorithm) -> 
         _  => panic!("Invalid HMAC algorithm")
     };
 
-    let buffer = read_key_file(key_path)?;
-    let pkey = PKey::hmac(&buffer)?;
+    let pkey = PKey::hmac(key)?;
     let mut signer = Signer::new(stp, &pkey)?;
     signer.update(data.as_bytes())?;
     signer.sign_to_vec().map_err(Error::from)
 }
 
-fn verify_signature<P: AsRef<Path>>(algorithm: Algorithm, signing_input: String, signature: &[u8], public_key: P) -> Result<bool, Error> {
+fn verify_signature<P: ToKey>(algorithm: Algorithm, signing_input: String, signature: &[u8], public_key: &P) -> Result<bool, Error> {
     match algorithm {
         Algorithm::HS256 | Algorithm::HS384 | Algorithm::HS512 => {
-            let signature2 = sign_hmac2(&signing_input, public_key, algorithm)?;
+            let signature2 = sign_hmac2(&signing_input, &public_key.to_key()?, algorithm)?;
             Ok(secure_compare(signature, &signature2))
         },
 
         Algorithm::RS256 | Algorithm::RS384 | Algorithm::RS512  => {
-            let buffer = read_key_file(public_key)?;
-            let rsa = Rsa::public_key_from_pem(&buffer)?;
+            let rsa = Rsa::public_key_from_pem(&public_key.to_key()?)?;
             let key = PKey::from_rsa(rsa)?;
 
             let digest = get_sha_algorithm(algorithm);
@@ -223,8 +234,7 @@ fn verify_signature<P: AsRef<Path>>(algorithm: Algorithm, signing_input: String,
             verifier.verify(&signature).map_err(Error::from)
         },
         Algorithm::ES256 | Algorithm::ES384 | Algorithm::ES512 => {
-            let raw_pem = read_key_file(public_key)?;
-            let key = PKey::public_key_from_pem(&raw_pem).map_err(Error::from)?;
+            let key = PKey::public_key_from_pem(&public_key.to_key()?).map_err(Error::from)?;
 
             let digest = get_sha_algorithm(algorithm);
             let mut verifier = Verifier::new(digest, &key)?;
@@ -260,34 +270,35 @@ fn secure_compare(a: &[u8], b: &[u8]) -> bool {
 mod tests {
     extern crate time;
 
-    use super::{Header, Payload, Algorithm};
-    use super::encode;
-    use super::decode;
-    use super::secure_compare;
+    use super::{Algorithm, encode, decode, secure_compare, STANDARD_HEADER_TYPE };
     use std::env;
+    use std::path::PathBuf;
 
     #[test]
     fn test_encode_and_decode_jwt_hs256() {
-        let mut p1 =  Payload::new();
-        p1.insert("key1".to_string(), "val1".to_string());
-        p1.insert("key2".to_string(), "val2".to_string());
-        p1.insert("key3".to_string(), "val3".to_string());
+        let p1 = json!({
+            "key1" : "val1",
+            "key2" : "val2",
+            "key3" : "val3"
+        });
 
-        let secret = "secret123";
-        let header = Header::new(Algorithm::HS256);
-        let jwt1 = encode(header, secret.to_string(), p1.clone());
-        let maybe_res = decode(jwt1, secret.to_string(), Algorithm::HS256);
+
+        let secret = "secret123".to_string();
+        let  header = json!({});
+        let jwt1 = encode(header, &secret, &p1, Algorithm::HS256).unwrap();
+        let maybe_res = decode(&jwt1, &secret, Algorithm::HS256);
         assert!(maybe_res.is_ok());
     }
 
     #[test]
     fn test_decode_valid_jwt_hs256() {
-        let mut p1 = Payload::new();
-        p1.insert("key11".to_string(), "val1".to_string());
-        p1.insert("key22".to_string(), "val2".to_string());
-        let secret = "secret123";
-        let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkxMSI6InZhbDEiLCJrZXkyMiI6InZhbDIifQ.jrcoVcRsmQqDEzSW9qOhG1HIrzV_n3nMhykNPnGvp9c";
-        let maybe_res = decode(jwt.to_string(), secret.to_string(), Algorithm::HS256);
+        let p1 = json!({
+            "key1" : "val1",
+            "key2" : "val2"
+        });
+        let secret = "secret123".to_string();
+        let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkxMSI6InZhbDEiLCJrZXkyMiI6InZhbDIifQ.jrcoVcRsmQqDEzSW9qOhG1HIrzV_n3nMhykNPnGvp9c".to_string();
+        let maybe_res = decode(&jwt, &secret, Algorithm::HS256);
         assert!(maybe_res.is_ok());
     }
 
@@ -309,120 +320,123 @@ mod tests {
 
     #[test]
     fn test_encode_and_decode_jwt_hs384() {
-        let mut p1 =  Payload::new();
-        p1.insert("key1".to_string(), "val1".to_string());
-        p1.insert("key2".to_string(), "val2".to_string());
-        p1.insert("key3".to_string(), "val3".to_string());
+        let p1 = json!({
+            "key1" : "val1",
+            "key2" : "val2",
+            "key3" : "val3"
+        });
 
-        let secret = "secret123";
-        let header = Header::new(Algorithm::HS384);
-        let jwt1 = encode(header, secret.to_string(), p1.clone());
-        let maybe_res = decode(jwt1, secret.to_string(), Algorithm::HS384);
+        let secret = "secret123".to_string();
+        let  header = json!({});
+        let jwt1 = encode(header, &secret, &p1, Algorithm::HS384).unwrap();
+        let maybe_res = decode(&jwt1, &secret, Algorithm::HS384);
         assert!(maybe_res.is_ok());
     }
 
     #[test]
     fn test_encode_and_decode_jwt_hs512() {
-        let mut p1 =  Payload::new();
-        p1.insert("key12".to_string(), "val1".to_string());
-        p1.insert("key22".to_string(), "val2".to_string());
-        p1.insert("key33".to_string(), "val3".to_string());
+        let p1 = json!({
+            "key1" : "val1",
+            "key2" : "val2",
+            "key3" : "val3"
+        });
 
-        let secret = "secret123456";
-        let header = Header::new(Algorithm::HS512);
-        let jwt1 = encode(header, secret.to_string(), p1.clone());
-        let maybe_res = decode(jwt1, secret.to_string(), Algorithm::HS512);
+        let secret = "secret123456".to_string();
+        let  header = json!({});
+        let jwt1 = encode(header, &secret, &p1, Algorithm::HS512).unwrap();
+        let maybe_res = decode(&jwt1, &secret, Algorithm::HS512);
         assert!(maybe_res.is_ok());
     }
 
     #[test]
     fn test_encode_and_decode_jwt_rs256() {
-        let mut p1 =  Payload::new();
-        p1.insert("key12".to_string(), "val1".to_string());
-        p1.insert("key22".to_string(), "val2".to_string());
-        p1.insert("key33".to_string(), "val3".to_string());
-        let header = Header::new(Algorithm::RS256);
-
+        let p1 = json!({
+            "key1" : "val1",
+            "key2" : "val2",
+            "key3" : "val3"
+        });
+        let  header = json!({}); 
         let mut path = env::current_dir().unwrap();
         path.push("test");
         path.push("my_rsa_2048_key.pem");
         path.to_str().unwrap().to_string();
 
-        let jwt1 = encode(header, get_rsa_256_private_key_full_path(), p1.clone());
-        let maybe_res = decode(jwt1, get_rsa_256_public_key_full_path(), Algorithm::RS256);
+        let jwt1 = encode(header, &get_rsa_256_private_key_full_path(), &p1, Algorithm::RS256).unwrap();
+        let maybe_res = decode(&jwt1, &get_rsa_256_public_key_full_path(), Algorithm::RS256);
         assert!(maybe_res.is_ok());
     }
 
     #[test]
     fn test_decode_valid_jwt_rs256() {
-        let mut p1 = Payload::new();
-        p1.insert("key1".to_string(), "val1".to_string());
-        p1.insert("key2".to_string(), "val2".to_string());
-        let header = Header::new(Algorithm::RS256);
-        let jwt1 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkxIjoidmFsMSIsImtleTIiOiJ2YWwyIn0.DFusERCFWCL3CkKBaoVKsi1Z3QO2NTTRDTGHPqm7ctzypKHxLslJXfS1p_8_aRX30V2osMAEfGzXO9U0S9J1Z7looIFNf5rWSEcqA3ah7b7YQ2iTn9LOiDWwzVG8rm_HQXkWq-TXqayA-IXeiX9pVPB9bnguKXy3YrLWhP9pxnhl2WmaE9ryn8WTleMiElwDq4xw5JDeopA-qFS-AyEwlc-CE7S_afBd5OQBRbvgtfv1a9soNW3KP_mBg0ucz5eUYg_ON17BG6bwpAwyFuPdDAXphG4hCsa7GlXea0f7DnYD5e5-CA6O7BPW_EvjaGhL_D9LNWHJuDiSDBwZ4-IEIg";
-        let jwt2 = encode(header, get_rsa_256_private_key_full_path(), p1.clone());
+        let p1 = json!({
+            "key1" : "val1",
+            "key2" : "val2"
+        });
+        let  header = json!({});
+        let jwt1 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkxIjoidmFsMSIsImtleTIiOiJ2YWwyIn0=.RQdLX70LEWL3PFePR2ec7fsBLwi29qK9GL_YfiBKcOWnWsgWMrw0PeJw8h21FloKAYYRq73GmSlF39B5TWbquscf3obfD_y3TYmSjY_STlQ1UTMBnCmwZeMgxuIlq4l7RNpGh_j-42u6YJ3b4zwFiiIGWANYTL0pzXjdIFcUhuY7yeYlFHmWgUOOfv_E_MaP0CgCK6rgeorPtFZ80Z-zYc2R7oXLylgiwJQmwLGzxAcOOcNaZurhQxUQ7GrErY9fOLxfw0vmF4FMSIhQvWIiUV9Meh3MoIwybDhuy5-Y85WZwtXYC7blAZhU0h6tFqwBozt7PS34htj8rkCIqqi0Ng==".to_string();
+        let (h1, p1) = decode(&jwt1, &get_rsa_256_public_key_full_path(), Algorithm::RS256).unwrap();
+        println!("\n{}",h1);
+        println!("{}",p1);
+        let jwt2 = encode(header, &get_rsa_256_private_key_full_path(), &p1, Algorithm::RS256).unwrap();
+        let (h2, p2) = decode(&jwt2, &get_rsa_256_public_key_full_path(), Algorithm::RS256).unwrap();
+        println!("{}",h2);
+        println!("{}",p2);
         assert_eq!(jwt1, jwt2);
     }
 
     #[test]
     fn test_decode_valid_jwt_rs256_and_check_deeply() {
-        let mut p1 = Payload::new();
-        p1.insert("key1".to_string(), "val1".to_string());
-        p1.insert("key2".to_string(), "val2".to_string());
-        let h1 = Header::new(Algorithm::RS256);
-        let jwt1 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkxIjoidmFsMSIsImtleTIiOiJ2YWwyIn0.DFusERCFWCL3CkKBaoVKsi1Z3QO2NTTRDTGHPqm7ctzypKHxLslJXfS1p_8_aRX30V2osMAEfGzXO9U0S9J1Z7looIFNf5rWSEcqA3ah7b7YQ2iTn9LOiDWwzVG8rm_HQXkWq-TXqayA-IXeiX9pVPB9bnguKXy3YrLWhP9pxnhl2WmaE9ryn8WTleMiElwDq4xw5JDeopA-qFS-AyEwlc-CE7S_afBd5OQBRbvgtfv1a9soNW3KP_mBg0ucz5eUYg_ON17BG6bwpAwyFuPdDAXphG4hCsa7GlXea0f7DnYD5e5-CA6O7BPW_EvjaGhL_D9LNWHJuDiSDBwZ4-IEIg";
-        let res = decode(jwt1.to_string(), get_rsa_256_public_key_full_path(), Algorithm::RS256);
-        match res {
-            Ok((h2, p2)) => {
-                assert_eq!(h1.ttype, h2.ttype);
-                assert_eq!(h1.algorithm.to_string(), h2.algorithm.to_string()); //todo implement ==
-                for (k, v) in &p1 {
-                    assert_eq!(true, p2.contains_key(k));
-                    assert_eq!(v, p2.get(k).unwrap());
-                }
-            },
-            Err(e) => panic!(e)
-        }
+        let p1 = json!({
+            "key1" : "val1",
+            "key2" : "val2"
+        });
+        let h1 = json!({"typ" : STANDARD_HEADER_TYPE, "alg" : Algorithm::RS256.to_string()});
+        let jwt1 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkxIjoidmFsMSIsImtleTIiOiJ2YWwyIn0=.RQdLX70LEWL3PFePR2ec7fsBLwi29qK9GL_YfiBKcOWnWsgWMrw0PeJw8h21FloKAYYRq73GmSlF39B5TWbquscf3obfD_y3TYmSjY_STlQ1UTMBnCmwZeMgxuIlq4l7RNpGh_j-42u6YJ3b4zwFiiIGWANYTL0pzXjdIFcUhuY7yeYlFHmWgUOOfv_E_MaP0CgCK6rgeorPtFZ80Z-zYc2R7oXLylgiwJQmwLGzxAcOOcNaZurhQxUQ7GrErY9fOLxfw0vmF4FMSIhQvWIiUV9Meh3MoIwybDhuy5-Y85WZwtXYC7blAZhU0h6tFqwBozt7PS34htj8rkCIqqi0Ng==".to_string();
+        let (h2, p2) = decode(&jwt1, &get_rsa_256_public_key_full_path(), Algorithm::RS256).unwrap();
+        assert_eq!(h1.get("typ").unwrap(), h2.get("typ").unwrap());
+        assert_eq!(h1.get("alg").unwrap(), h2.get("alg").unwrap());
+        assert_eq!(p1, p2);
     }
 
     #[test]
     fn test_encode_and_decode_jwt_ec() {
-        let mut p1 =  Payload::new();
-        p1.insert("key12".to_string(), "val1".to_string());
-        p1.insert("key22".to_string(), "val2".to_string());
-        p1.insert("key33".to_string(), "val3".to_string());
-        let header = Header::new(Algorithm::ES512);
+        let p1 = json!({
+            "key1" : "val1",
+            "key2" : "val2",
+            "key3" : "val3"
+        });
+        let header = json!({});
 
-        let jwt1 = encode(header, get_ec_private_key_path(), p1.clone());
-        let maybe_res = decode(jwt1, get_ec_public_key_path(), Algorithm::ES512);
+        let jwt1 = encode(header, &get_ec_private_key_path(), &p1, Algorithm::ES512).unwrap();
+        let maybe_res = decode(&jwt1, &get_ec_public_key_path(), Algorithm::ES512);
         assert!(maybe_res.is_ok());
     }
 
-    fn get_ec_private_key_path() -> String {
+    fn get_ec_private_key_path() -> PathBuf {
         let mut path = env::current_dir().unwrap();
         path.push("test");
         path.push("ec_x9_62_prime256v1.private.key.pem");
-        path.to_str().unwrap().to_string()
+        path.to_path_buf()
     }
 
-    fn get_ec_public_key_path() -> String {
+    fn get_ec_public_key_path() -> PathBuf {
         let mut path = env::current_dir().unwrap();
         path.push("test");
         path.push("ec_x9_62_prime256v1.public.key.pem");
-        path.to_str().unwrap().to_string()
+        path.to_path_buf()
     }
 
-    fn get_rsa_256_private_key_full_path() -> String {
+    fn get_rsa_256_private_key_full_path() -> PathBuf {
         let mut path = env::current_dir().unwrap();
         path.push("test");
         path.push("my_rsa_2048_key.pem");
-        path.to_str().unwrap().to_string()
+        path.to_path_buf()
     }
 
-    fn get_rsa_256_public_key_full_path() -> String {
+    fn get_rsa_256_public_key_full_path() -> PathBuf {
         let mut path = env::current_dir().unwrap();
         path.push("test");
         path.push("my_rsa_public_2048_key.pem");
-        path.to_str().unwrap().to_string()
+        path.to_path_buf()
     }
 }


### PR DESCRIPTION
Apologies, for the monolithic PR, but it is kind of hard to dice this one up.  The core of the changes are around : 

1. Making the interface more flexible re: headers and payloads. 
2. Removing the possibility of panics at runtime. (Using Result and idiomatic error handling)
3. Get rid of the deprecated rustc_serialize interface. 

In addition, I added a few optimizations by taking references and removing clones. 
I also found a significant issue where the key was being treated as either a key, or a path to a key, this seemed dangerous to me.  I like the simple interface, though, so I added a trait which interprets a PathBuf as a path to a key,  or if a string is supplied, then it is assumed that it is the key body itself.  We can add additional validation for this later. 

Also, the jwt token in the unit tests wasn't a valid payload+signature according to https://jwt.io,  the payload was missing a `=` at the end,  which might have been a base64 encoding error from the previous lib. Hard to say.  Either way, the current one is valid according to the website. 

My error management additions could do a better job of maintaining and passing-on the error details of the underlying errors (especially for Io and OpenSSL)  But we can do that later. 
  