### PR TITLE
WIP: Improve api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ const SEGMENTS_COUNT: usize = 3;
 
 const STANDARD_HEADER_TYPE: &str = "JWT";
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Algorithm {
     HS256,
     HS384,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,6 @@ fn verify_aud() {
 #[cfg(test)]
 mod tests {
     use super::{Algorithm, encode, decode, validate_signature, secure_compare, STANDARD_HEADER_TYPE};
-    use std::env;
     use std::path::PathBuf;
 
     #[test]
@@ -656,45 +655,31 @@ mod tests {
         assert_eq!(p1, payload);
     }
 
+    fn test_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test").join(name)
+    }
+
     fn get_ec_private_key_path() -> PathBuf {
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("ec_x9_62_prime256v1.private.key.pem");
-        path.to_path_buf()
+        test_path("ec_x9_62_prime256v1.private.key.pem")
     }
 
     fn get_ec_public_key_path() -> PathBuf {
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("ec_x9_62_prime256v1.public.key.pem");
-        path.to_path_buf()
+        test_path("ec_x9_62_prime256v1.public.key.pem")
     }
 
     fn get_bad_ec_public_key_path() -> PathBuf {
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("ec_2_x9_62_prime256v1.public.key.pem");
-        path.to_path_buf()
+        test_path("ec_2_x9_62_prime256v1.public.key.pem")
     }
 
     fn get_rsa_256_private_key_full_path() -> PathBuf {
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("my_rsa_2048_key.pem");
-        path.to_path_buf()
+        test_path("my_rsa_2048_key.pem")
     }
 
     fn get_rsa_256_public_key_full_path() -> PathBuf {
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("my_rsa_public_2048_key.pem");
-        path.to_path_buf()
+        test_path("my_rsa_public_2048_key.pem")
     }
 
     fn get_bad_rsa_256_public_key_full_path() -> PathBuf {
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("my_bad_rsa_public_2048_key.pem");
-        path.to_path_buf()
+        test_path("my_bad_rsa_public_2048_key.pem")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,8 @@ pub enum Algorithm {
     ES512
 }
 
-impl ToString for Algorithm {
-    fn to_string(&self) -> String {
+impl Algorithm {
+    pub fn as_str(&self) -> &'static str {
         match *self {
             Algorithm::HS256 => "HS256",
             Algorithm::HS384 => "HS384",
@@ -75,7 +75,13 @@ impl ToString for Algorithm {
             Algorithm::ES256 => "ES256",
             Algorithm::ES384 => "ES384",
             Algorithm::ES512 => "ES512"
-        }.to_string()
+        }
+    }
+}
+
+impl ToString for Algorithm {
+    fn to_string(&self) -> String {
+        self.as_str().to_string()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,11 +497,6 @@ mod tests {
             "key3" : "val3"
         });
         let  header = json!({});
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("my_rsa_2048_key.pem");
-        path.to_str().unwrap().to_string();
-
         let jwt1 = encode(header, &get_rsa_256_private_key_full_path(), &p1, Algorithm::RS256).unwrap();
         let maybe_res = decode(&jwt1, &get_rsa_256_public_key_full_path(), Algorithm::RS256);
         assert!(maybe_res.is_ok());
@@ -515,10 +510,6 @@ mod tests {
             "key3" : "val3"
         });
         let  header = json!({});
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("my_rsa_2048_key.pem");
-        path.to_str().unwrap().to_string();
 
         let jwt1 = encode(header, &get_rsa_256_private_key_full_path(), &p1, Algorithm::RS256).unwrap();
         let maybe_res = validate_signature(&jwt1, &get_rsa_256_public_key_full_path(), Algorithm::RS256);
@@ -533,10 +524,6 @@ mod tests {
             "key3" : "val3"
         });
         let  header = json!({});
-        let mut path = env::current_dir().unwrap();
-        path.push("test");
-        path.push("my_rsa_2048_key.pem");
-        path.to_str().unwrap().to_string();
 
         let jwt1 = encode(header, &get_rsa_256_private_key_full_path(), &p1, Algorithm::RS256).unwrap();
         let maybe_res = validate_signature(&jwt1, &get_bad_rsa_256_public_key_full_path(), Algorithm::RS256);


### PR DESCRIPTION
---
This builds on top of #33. The biggest differences:

  - Removal of the `ToKey` trait. Instead, `AsRef<[u8]>` is preferred.
  - Addition of `encode_jwt` to avoid having to give an empty parameter all the time for the common case.