### PR TITLE
Updated rust-openssl dependency to 0.10.x

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+use_try_shorthand = true
+use_field_init_shorthand = true
+max_width = 120
+newline_style = "Unix"
+merge_derives = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/GildedHonour/frank_jwt"
 version = "3.0.2"
 
 [dependencies]
-base64 = "0.9.0"
-openssl = "^0.9"
-serde = "^1"
-serde_json = "^1"
+base64 = "0.9"
+openssl = "0.10"
+serde = "1.0"
+serde_json = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,6 @@
+use base64::DecodeError as B64Error;
+use openssl::error::ErrorStack;
+use serde_json::Error as SJError;
 /**
  * Copyright (c) 2015-2018 Alex Maslakov, <gildedhonour.com>, <alexmaslakov.me>
  *
@@ -18,11 +21,7 @@
  * https://github.com/GildedHonour/frank_jwt
  *
  */
-
 use std::io::Error as IoError;
-use serde_json::Error as SJError;
-use openssl::error::ErrorStack;
-use base64::DecodeError as B64Error;
 
 macro_rules! impl_error {
     ($from:ty, $to:path) => {
@@ -31,7 +30,7 @@ macro_rules! impl_error {
                 $to(format!("{:?}", e))
             }
         }
-    }
+    };
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Includes: 
- Added a rustfmt.toml to enforce standard styling
- Rustfmt pass
- Dependencies version requirements formats to be more in-line with standards
- Upgraded rust-openssl to 0.10.x to prevent errors on install and not being able to use OpenSSL 1.1.1


Tests are passing