### PR TITLE
Update openssl crate to version 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ version = "3.0.2"
 
 [dependencies]
 base64 = "0.9.0"
-openssl = "^0.9"
+openssl = "^0.10"
 serde = "^1"
 serde_json = "^1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use std::path::{PathBuf};
 use std::io::Read;
 use std::str;
 use openssl::hash::MessageDigest;
-use openssl::pkey::PKey;
+use openssl::pkey::{PKey, Private};
 use openssl::rsa::Rsa;
 use openssl::sign::{Signer, Verifier};
 use openssl::ec::EcKey;
@@ -182,7 +182,7 @@ fn sign_es<P: ToKey>(data: &str, private_key_path: &P, algorithm: Algorithm) -> 
     sign(data, key, stp)
 }
 
-fn sign(data: &str, private_key: PKey,digest: MessageDigest) -> Result<String, Error> {
+fn sign(data: &str, private_key: PKey<Private>, digest: MessageDigest) -> Result<String, Error> {
     let mut signer = Signer::new(digest, &private_key)?;
     signer.update(data.as_bytes())?;
     let signature = signer.sign_to_vec()?;


### PR DESCRIPTION
Update the openssl crate to allow use with recently released versions of the openssl library, see [this issue](https://github.com/sfackler/rust-openssl/issues/994) for context.