### PR TITLE
Added std::error::Error impl for jwt error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,8 @@ use std::io::Error as IoError;
 use serde_json::Error as SJError;
 use openssl::error::ErrorStack;
 use base64::DecodeError as B64Error;
+use std::error;
+use std::fmt;
 
 macro_rules! impl_error {
     ($from:ty, $to:path) => {
@@ -47,6 +49,25 @@ pub enum Error {
     OpenSslError(String),
     ProtocolError(String),
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::SignatureExpired => write!(f, "Signature expired."),
+            Error::SignatureInvalid => write!(f, "Signature invalid."),
+            Error::JWTInvalid => write!(f, "JWT invalid."),
+            Error::IssuerInvalid => write!(f, "Issuer invalid."),
+            Error::ExpirationInvalid => write!(f, "Expiration invalid."),
+            Error::AudienceInvalid => write!(f, "Audience invalid."),
+            Error::FormatInvalid(msg) => write!(f, "Format invalid: {}.", msg),
+            Error::IoError(msg) => write!(f, "Format invalid: {}.", msg),
+            Error::OpenSslError(msg) => write!(f, "Format invalid: {}.", msg),
+            Error::ProtocolError(msg) => write!(f, "Format invalid: {}.", msg),
+        }
+    }
+}
+
+impl error::Error for Error {}
 
 impl_error!{IoError, Error::IoError}
 impl_error!{SJError, Error::FormatInvalid}


### PR DESCRIPTION
Implemented the standard Rust error on the main error enum of the lib. This enables easy interaction with libs like https://crates.io/crates/failure that requires std::error:Error implemented in error types.