### PR TITLE
Refactor function &String parameters to &str

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub fn encode<P: ToKey>(mut header: JsonValue, signing_key: &P, payload: &JsonVa
     Ok(format!("{}.{}", signing_input, signature))
 }
 
-pub fn decode<P: ToKey>(encoded_token: &String, signing_key: &P, algorithm: Algorithm) -> Result<(JsonValue, JsonValue), Error> {
+pub fn decode<P: ToKey>(encoded_token: &str, signing_key: &P, algorithm: Algorithm) -> Result<(JsonValue, JsonValue), Error> {
     let (header, payload, signature, signing_input) = decode_segments(encoded_token)?;
     if !verify_signature(algorithm, signing_input, &signature, signing_key)? {
         Err(Error::SignatureInvalid)
@@ -128,7 +128,7 @@ pub fn decode<P: ToKey>(encoded_token: &String, signing_key: &P, algorithm: Algo
     }
 }
 
-pub fn validate_signature<P: ToKey>(encoded_token: &String, signing_key: &P, algorithm: Algorithm) -> Result<bool, Error> {
+pub fn validate_signature<P: ToKey>(encoded_token: &str, signing_key: &P, algorithm: Algorithm) -> Result<bool, Error> {
     let (signature, signing_input) = decode_signature_segments(encoded_token)?;
     verify_signature(algorithm, signing_input, &signature, signing_key)
 }
@@ -189,7 +189,7 @@ fn sign(data: &str, private_key: PKey<Private>, digest: MessageDigest) -> Result
     Ok(b64_enc(signature.as_slice(), base64::URL_SAFE_NO_PAD))
 }
 
-fn decode_segments(encoded_token: &String) -> Result<(JsonValue, JsonValue, Vec<u8>, String), Error> {
+fn decode_segments(encoded_token: &str) -> Result<(JsonValue, JsonValue, Vec<u8>, String), Error> {
     let raw_segments: Vec<&str> = encoded_token.split(".").collect();
     if raw_segments.len() != SEGMENTS_COUNT {
         return Err(Error::JWTInvalid);
@@ -204,7 +204,7 @@ fn decode_segments(encoded_token: &String) -> Result<(JsonValue, JsonValue, Vec<
     Ok((header, payload, signature.clone(), signing_input))
 }
 
-fn decode_signature_segments(encoded_token: &String) -> Result<(Vec<u8>, String), Error> {
+fn decode_signature_segments(encoded_token: &str) -> Result<(Vec<u8>, String), Error> {
     let raw_segments: Vec<&str> = encoded_token.split(".").collect();
     if raw_segments.len() != SEGMENTS_COUNT {
         return Err(Error::JWTInvalid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,12 @@ impl ToKey for String {
     }
 }
 
+impl ToKey for &str {
+    fn to_key(&self) -> Result<Vec<u8>, Error> {
+        Ok(self.as_bytes().to_vec())
+    }
+}
+
 impl ToKey for Vec<u8> {
     fn to_key(&self) -> Result<Vec<u8>, Error> {
         Ok(self.clone())
@@ -347,7 +353,7 @@ mod tests {
             "key3" : "val3"
         });
 
-        let secret = "secret123".to_string();
+        let secret = "secret123";
         let  header = json!({});
         let jwt1 = encode(header, &secret, &p1, Algorithm::HS256).unwrap();
         let maybe_res = decode(&jwt1, &secret, Algorithm::HS256);


### PR DESCRIPTION
It's a more idiomatic way to pass string references to functions. Hope this is welcome. Thanks!