### PR TITLE
Add lifetime annotation for impl ToKey for &str

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl ToKey for String {
     }
 }
 
-impl ToKey for &str {
+impl<'a> ToKey for &'a str {
     fn to_key(&self) -> Result<Vec<u8>, Error> {
         Ok(self.as_bytes().to_vec())
     }


### PR DESCRIPTION
Older Rust versions (e.g. 1.29.2) can't infer the lifetime
automatically, so the crate fails to build.