### PR TITLE
Implement the exp check

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Implementation of [JSON Web Tokens](http://jwt.io) in Rust.
 - [x] ES512
 - [x] Sign
 - [x] Verify
-- [x] iss (issuer) check
-- [x] sub (subject) check
-- [x] aud (audience) check
+- [ ] iss (issuer) check
+- [ ] sub (subject) check
+- [ ] aud (audience) check
 - [x] exp (expiration time) check
-- [x] nbf (not before time) check
-- [x] iat (issued at) check
-- [x] jti (JWT id) check
+- [ ] nbf (not before time) check
+- [ ] iat (issued at) check
+- [ ] jti (JWT id) check
 
 ## Usage
 
@@ -68,8 +68,18 @@ let mut keypath = env::current_dir().unwrap();
 keypath.push("some_folder");
 keypath.push("my_rsa_2048_key.pem");
 let jwt = encode(&header, &keypath.to_path_buf(), &payload, Algorithm::RS256);
-let (header, payload) = decode(&jwt, &keypath.to_path_buf(), Algorithm::RS256);
+let (header, payload) = decode(&jwt, &keypath.to_path_buf(), Algorithm::RS256, &ValidationOptions::default());
 ```
+
+## Validation Options
+The ValidationOptions structure allows for control over which checks should be preformed when decoding a JWT. Calling new on this will provide a default set of values. There is also a dangerous function that will return validation options that doesn't perform any checking.
+
+The default values are:
+
+* Perform expiry check
+* Allow 0 leeway for the expiry check.
+
+It's worth noting that if the expiry check is requested and an exp claim is not within the JWT the check will fail validation.
 
 ## License
 


### PR DESCRIPTION
Implementation of the expiry claim check along with the ability to add leeway to the check. 

I have added ValidationOptions that are passed to the decode function to allow for the end user to turn off the check, along with providing a value for the leeway. This causes an API breaking change.